### PR TITLE
W14 and S14 reports are now tech notes so reference them directly

### DIFF
--- a/DMTN-017.tex
+++ b/DMTN-017.tex
@@ -42,9 +42,7 @@ Like any medium, the Earth's atmosphere refracts incident light, which for an ob
 \section{DCR literature}
 A quick summary of and notes on the existing literature covering DCR. Each reference we found is covered in it's own subsection below.
 
-\subsection{Report on Summer 2014 Production: Analysis of DCR (Andrew Becker)}
-
-\url{https://github.com/lsst-dm/S14DCR/blob/master/report/S14report_V0-00.pdf}
+\subsection{Report on Summer 2014 Production: Analysis of DCR \citedsp{DMTN-070}}
 
 \begin{itemize}
 	\item Estimated DCR effects directly for LSST using catSim's stellar
@@ -83,7 +81,7 @@ A quick summary of and notes on the existing literature covering DCR. Each refer
 **Recommendations**:
 \begin{itemize}
 	\item Code from the S14DCR analysis
-          \url{https://github.com/lsst-dm/S14DCR} should be updated to
+          (\url{https://github.com/lsst-dm/DMTN-070}) should be updated to
           use latest version of sims\_photUtils and include estimates
           for galaxies and SNe.
 %	\item Potentially merge capabilities of SED and Bandpass in sims\_photUtils with those from chroma \url{https://github.com/DarkEnergyScienceCollaboration/chroma/}; see below.
@@ -91,7 +89,7 @@ A quick summary of and notes on the existing literature covering DCR. Each refer
           to compare the results of these simulations to DCR effects
           in simulated images, and to enable investigation of DCR
           corrections on image coadds and differences (see also
-          \url{https://github.com/lsst-dm/W14ImageDifferencing}).
+          \url{https://github.com/lsst-dm/W14ImageDifferencing} and \citeds{DMTN-069}).
 \end{itemize}
 
 


### PR DESCRIPTION
Upgrade the references for the new DMTN-069 and DMTN-070 versions of the reports.

@isullivan I see this tech note still refers to isullivan/LSST-DCR. Is that right? Should we break the forked connection between this repo and that one?